### PR TITLE
Attempt crash fix, add new api command

### DIFF
--- a/JavascriptApi.h
+++ b/JavascriptApi.h
@@ -83,6 +83,7 @@ public:
 		JS_ENUM_SCENES,
 		JS_RESTART_OBS,
 		JS_SL_VERSION_INFO,
+		JS_SAVE_SL_BROWSER_DOCKS,
 	};
 
 public:
@@ -147,6 +148,11 @@ public:
 			// .(@function(arg1), @objectName, @newTitle)
 			//	Renames a dock's objectName, which must be unique and not match any other existing
 			{"dock_setTitle", JS_DOCK_SETTITLE},
+
+			// .(@function(arg1)
+			//	This is automatically done when the user gracefully closes the program
+			//	However, the program might not gracefully close, so this can be used to save to their OBS config the existence of the docks
+			{"dock_saveSlabsBrowserDocks", JS_SAVE_SL_BROWSER_DOCKS},
 
 			/***
 			* Qt Information

--- a/PluginJsHandler.h
+++ b/PluginJsHandler.h
@@ -100,6 +100,7 @@ private:
 	void JS_ENUM_SCENES(const json11::Json &params, std::string &out_jsonReturn);
 	void JS_RESTART_OBS(const json11::Json &params, std::string &out_jsonReturn);
 	void JS_GET_IS_OBS_STREAMING(const json11::Json &params, std::string &out_jsonReturn);
+	void JS_SAVE_SL_BROWSER_DOCKS(const json11::Json &params, std::string &out_jsonReturn);
 
 	std::wstring getDownloadsDir() const;
 	std::wstring getFontsDir() const;


### PR DESCRIPTION
saveSlabsBrowserDocks iterates Qt objects on shutdown, and iterating Qt objects outside of QMetaObject::invokeMethod is typically unsafe