### PR TITLE
Fix obs-studio 30.2.0 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
+# OBS 28.x.x?
+if (NOT COMMAND legacy_check)
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
+  endif()
+  return()
+endif()
+
 legacy_check()
 
 find_package(CEF REQUIRED)

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
-legacy_check()
-
 find_package(CEF REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Detours REQUIRED)
 
-find_package(Qt6 REQUIRED Widgets)
+find_qt(COMPONENTS Widgets)
 
 include(FindGRPC.cmake)
 


### PR DESCRIPTION
Moves the old script to the legacy subfolder and fixes errors for the current build environment