### PR TITLE
fix: disable legacy build, details follow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,19 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
 # OBS 28.x.x?
-if (NOT COMMAND legacy_check)
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
-  endif()
-  return()
-endif()
+# FIXME: legacy_check macro was removed in
+# https://github.com/obsproject/obs-studio/commit/31385006d5442a33c3d4cf8307a3f921a13773d6
+# This seems to always pass and legacy cmake files are included, which also need
+# to fix usage of removed `find_qt` macro.
+# Disable legacy building then
+# if (NOT COMMAND legacy_check)
+#   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
+#     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/legacy.cmake)
+#   endif()
+#   return()
+# endif()
 
-legacy_check()
+# legacy_check()
 
 find_package(CEF REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -21,7 +26,7 @@ include(FindGRPC.cmake)
 ## -- Grpc between plugin and proxy
 
 # Proto file
-get_filename_component(papi_proto "sl_browser_api.proto" ABSOLUTE) 
+get_filename_component(papi_proto "sl_browser_api.proto" ABSOLUTE)
 get_filename_component(papi_proto_path "${papi_proto}" PATH)
 
 message ("${CMAKE_CURRENT_BINARY_DIR}")
@@ -94,7 +99,7 @@ target_sources(
           deps/signal-restore.hpp
 		      ${papi_proto_srcs}
 		      ${papi_grpc_srcs})
-          
+
 target_include_directories(sl-browser PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps")
 
 target_compile_features(sl-browser PRIVATE cxx_std_17)
@@ -103,15 +108,15 @@ target_link_libraries(sl-browser PRIVATE CEF::Wrapper CEF::Library d3d11 dxgi)
 target_link_libraries(sl-browser PRIVATE Qt::Widgets Qt::Core Qt::Gui)
 target_link_libraries(sl-browser PRIVATE Detours::Detours)
 
-target_link_libraries(sl-browser PRIVATE 
+target_link_libraries(sl-browser PRIVATE
 	  papi_grpc_proto
 	  ${_REFLECTION}
 	  ${_GRPC_GRPCPP}
 	  ${_PROTOBUF_LIBPROTOBUF})
 
-target_link_options(sl-browser PRIVATE 
+target_link_options(sl-browser PRIVATE
   "/IGNORE:4099" # Ignore PDB warnings
-  "/IGNORE:4098" 
+  "/IGNORE:4098"
 )
 
 target_compile_options(sl-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
@@ -174,11 +179,11 @@ target_link_libraries(sl-browser-plugin PRIVATE
   ${_GRPC_GRPCPP}
   ${_PROTOBUF_LIBPROTOBUF})
 
-target_link_options(sl-browser-plugin PRIVATE 
+target_link_options(sl-browser-plugin PRIVATE
   "/IGNORE:4099" # Ignore PDB warnings
-  "/IGNORE:4098" 
+  "/IGNORE:4098"
 )
-target_compile_options(sl-browser-plugin PRIVATE 
+target_compile_options(sl-browser-plugin PRIVATE
   "/wd4996" # 'obs_frontend_add_dock': was declared deprecated
 )
 
@@ -196,7 +201,7 @@ target_link_libraries(sl-browser-page PRIVATE CEF::Library)
 
 target_include_directories(sl-browser-page PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
                                                     ${CMAKE_CURRENT_SOURCE_DIR}/sl-browser-page)
-                                                    
+
 target_sources(sl-browser-page PRIVATE sl-browser-page.manifest)
 
 target_compile_features(sl-browser-page PRIVATE cxx_std_17)

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -4,14 +4,25 @@ find_package(CEF REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Detours REQUIRED)
 
-find_qt(COMPONENTS Widgets)
+# removed: find_qt(COMPONENTS Widgets)
+# this is untested, I've disabled legacy building completely, code is from plugin template
+find_package(Qt6 COMPONENTS Widgets Core)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt6::Core Qt6::Widgets)
+  target_compile_options(
+    ${CMAKE_PROJECT_NAME}
+    PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header -Wno-comma>
+  )
+  set_target_properties(
+    ${CMAKE_PROJECT_NAME}
+    PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON
+)
 
 include(FindGRPC.cmake)
 
 ## -- Grpc between plugin and proxy
 
 # Proto file
-get_filename_component(papi_proto "sl_browser_api.proto" ABSOLUTE) 
+get_filename_component(papi_proto "sl_browser_api.proto" ABSOLUTE)
 get_filename_component(papi_proto_path "${papi_proto}" PATH)
 
 message ("${CMAKE_CURRENT_BINARY_DIR}")
@@ -84,7 +95,7 @@ target_sources(
           deps/signal-restore.hpp
 		      ${papi_proto_srcs}
 		      ${papi_grpc_srcs})
-          
+
 target_include_directories(sl-browser PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/deps")
 
 target_compile_features(sl-browser PRIVATE cxx_std_17)
@@ -93,15 +104,15 @@ target_link_libraries(sl-browser PRIVATE CEF::Wrapper CEF::Library d3d11 dxgi)
 target_link_libraries(sl-browser PRIVATE Qt::Widgets Qt::Core Qt::Gui)
 target_link_libraries(sl-browser PRIVATE Detours::Detours)
 
-target_link_libraries(sl-browser PRIVATE 
+target_link_libraries(sl-browser PRIVATE
 	  papi_grpc_proto
 	  ${_REFLECTION}
 	  ${_GRPC_GRPCPP}
 	  ${_PROTOBUF_LIBPROTOBUF})
 
-target_link_options(sl-browser PRIVATE 
+target_link_options(sl-browser PRIVATE
   "/IGNORE:4099" # Ignore PDB warnings
-  "/IGNORE:4098" 
+  "/IGNORE:4098"
 )
 
 target_compile_options(sl-browser PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
@@ -164,11 +175,11 @@ target_link_libraries(sl-browser-plugin PRIVATE
   ${_GRPC_GRPCPP}
   ${_PROTOBUF_LIBPROTOBUF})
 
-target_link_options(sl-browser-plugin PRIVATE 
+target_link_options(sl-browser-plugin PRIVATE
   "/IGNORE:4099" # Ignore PDB warnings
-  "/IGNORE:4098" 
+  "/IGNORE:4098"
 )
-target_compile_options(sl-browser-plugin PRIVATE 
+target_compile_options(sl-browser-plugin PRIVATE
   "/wd4996" # 'obs_frontend_add_dock': was declared deprecated
 )
 
@@ -186,7 +197,7 @@ target_link_libraries(sl-browser-page PRIVATE CEF::Library)
 
 target_include_directories(sl-browser-page PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps
                                                     ${CMAKE_CURRENT_SOURCE_DIR}/sl-browser-page)
-                                                    
+
 target_sources(sl-browser-page PRIVATE sl-browser-page.manifest)
 
 target_compile_features(sl-browser-page PRIVATE cxx_std_17)


### PR DESCRIPTION
* `legacy_check` was removed in https://github.com/obsproject/obs-studio/commit/31385006d5442a33c3d4cf8307a3f921a13773d6 making the check somehow always branch in and include legacy cmake files.
* Those use `find_qt` which was also removed in https://github.com/obsproject/obs-studio/commit/8a7ad1026212e103c3c8b2dc0a0afcc907f83f89 resulting in broken legacy build.
* A replacement for `find_qt` is provided on this commit, but untested.
* I've just disabled legacy build completely, until we can figure out what else changed since last touched.

I've no idea what I'm doing.